### PR TITLE
feat(free_storage_space_threshold): increase alarm from 2 GB to 40 GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ module "rds_alarms" {
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_id | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
-| free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
+| free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `40000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |
 | swap_usage_threshold | The maximum amount of swap space used on the DB instance in Byte. | string | `256000000` | no |
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -8,7 +8,7 @@
 | cpu_utilization_threshold | The maximum percentage of CPU utilization. | string | `80` | no |
 | db_instance_id | The instance ID of the RDS database instance that you want to monitor. | string | - | yes |
 | disk_queue_depth_threshold | The maximum number of outstanding IOs (read/write requests) waiting to access the disk. | string | `64` | no |
-| free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `2000000000` | no |
+| free_storage_space_threshold | The minimum amount of available storage space in Byte. | string | `40000000000` | no |
 | freeable_memory_threshold | The minimum amount of available random access memory in Byte. | string | `64000000` | no |
 | swap_usage_threshold | The maximum amount of swap space used on the DB instance in Byte. | string | `256000000` | no |
 

--- a/variables.tf
+++ b/variables.tf
@@ -38,9 +38,9 @@ variable "freeable_memory_threshold" {
 variable "free_storage_space_threshold" {
   description = "The minimum amount of available storage space in Byte."
   type        = string
-  default     = 2000000000
+  default     = 40000000000
 
-  # 2 Gigabyte in Byte
+  # 40 Gigabytes in Bytes
 }
 
 variable "swap_usage_threshold" {


### PR DESCRIPTION
## What/Why?

Increased `free_storage_space_threshold` alarm limit from 2 GB to 40 GB